### PR TITLE
Remove `create_skill` function

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -169,7 +169,3 @@ class AboutSkill(NeonSkill):
 
     def stop(self):
         pass
-
-
-def create_skill():
-    return AboutSkill()

--- a/__init__.py
+++ b/__init__.py
@@ -44,7 +44,7 @@ from mycroft.skills import skill_api_method, intent_handler
 
 class AboutSkill(NeonSkill):
     def __init__(self):
-        super(AboutSkill, self).__init__(name="AboutSkill")
+        NeonSkill.__init__(self)
         self.skill_info = None
         # TODO: Reload skills list when skills are added/removed DM
         self._update_skills_data()

--- a/__init__.py
+++ b/__init__.py
@@ -43,8 +43,8 @@ from mycroft.skills import skill_api_method, intent_handler
 
 
 class AboutSkill(NeonSkill):
-    def __init__(self):
-        NeonSkill.__init__(self)
+    def __init__(self, **kwargs):
+        NeonSkill.__init__(self, **kwargs)
         self.skill_info = None
         # TODO: Reload skills list when skills are added/removed DM
         self._update_skills_data()


### PR DESCRIPTION
# Description
Deprecate `create_skill` function
Handle kwargs in `__init__`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This removes backwards-compat with Mycroft but resolves logged warnings and encourages better packaging practices