### PR TITLE
feat: fix import for ovos-utils 0.1.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -31,7 +31,7 @@ import json
 from typing import List
 from random import shuffle
 from os.path import isdir
-from ovos_utils.skills.locations import get_skill_directories, get_plugin_skills
+from ovos_plugin_manager.skills import get_skill_directories, get_plugin_skills
 from ovos_utils import classproperty
 from ovos_utils.process_utils import RuntimeRequirements
 from neon_utils.skills.neon_skill import NeonSkill


### PR DESCRIPTION
# Description
Adjusts a deprecated import that fails with ovos-utlis 0.1.0

# Issues
N/A

# Other Notes
Should be backwards-compatible